### PR TITLE
fix: observe txns in ascending order

### DIFF
--- a/notification_discord_bot/main.py
+++ b/notification_discord_bot/main.py
@@ -64,7 +64,12 @@ class MessageSender:
 def check_for_updates(msg_sender: MessageSender):
     for contract in all_contracts:
         if contract_is_enabled(contract):
-            for renft_datum in [*contract.get_lendings(), *contract.get_rentings()]:
+            # Reversed because the order is originally descending,
+            # but we want observe in ascending order
+            for renft_datum in [
+                *reversed(contract.get_lendings()),
+                *reversed(contract.get_rentings()),
+            ]:
                 if renft_datum.has_been_observed():
                     continue
                 renft_datum.observe()


### PR DESCRIPTION
Imagine we have Lending 1,2,3,4. renft_id is 2. Previous behaviour was observe 4 then 3 (descending), but if 4 is observed first, it will think that 3 has already been observed. To fix this, we reverse the order that we observe to ascending. Resetting our example with the new behaviour, 1 and 2 have already been observed. 3 gets observed and then 4 gets observed.